### PR TITLE
fix ERROR: unknown expr type *ast.IndexListExpr

### DIFF
--- a/nargs.go
+++ b/nargs.go
@@ -349,6 +349,10 @@ func (v *unusedVisitor) handleExprs(paramMap map[string]bool, exprList []ast.Exp
 		case *ast.Ellipsis:
 			exprList = append(exprList, e.Elt)
 
+		case *ast.IndexListExpr:
+			exprList = append(exprList, e.X)
+			exprList = append(exprList, e.Indices...)
+
 		case nil:
 			// no op
 

--- a/testdata/success.go
+++ b/testdata/success.go
@@ -12,3 +12,10 @@ func FuncVars(x int) {
 	}
 	do()
 }
+
+func newTypePair[K any, V any]() {
+}
+
+func testIndexListExpr() {
+	newTypePair[int, int]
+}


### PR DESCRIPTION
Fix `ERROR: unknown expr type *ast.IndexListExpr`
With a test.