### PR TITLE
Refactor `Visit`, improve `unknown stmt/expr type` errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 cmd/nargs/nargs
+/nargs
+nargs.exe

--- a/nargs.go
+++ b/nargs.go
@@ -125,17 +125,24 @@ func (v *unusedVisitor) Visit(node ast.Node) ast.Visitor {
 	v.handleStmts(paramMap, stmtList)
 
 	for paramName, used := range paramMap {
-		if !used {
-			if file != nil {
-				if funcDecl != nil && funcDecl.Name != nil {
-					// TODO print parameter vs parameter(s)?
-					// TODO differentiation of used parameter vs. receiver?
-					resStr := fmt.Sprintf("%v:%v %v contains unused parameter %v\n", file.Name(), file.Position(funcDecl.Pos()).Line, funcDecl.Name.Name, paramName)
-					v.resultsSet[resStr] = struct{}{}
-					v.errsFound = true
-				}
-			}
+		if used {
+			continue
 		}
+		if file == nil {
+			continue
+		}
+		if funcDecl == nil {
+			continue
+		}
+		if funcDecl.Name == nil {
+			continue
+		}
+
+		// TODO print parameter vs parameter(s)?
+		// TODO differentiation of used parameter vs. receiver?
+		resStr := fmt.Sprintf("%v:%v %v contains unused parameter %v\n", file.Name(), file.Position(funcDecl.Pos()).Line, funcDecl.Name.Name, paramName)
+		v.resultsSet[resStr] = struct{}{}
+		v.errsFound = true
 	}
 
 	return v

--- a/nargs.go
+++ b/nargs.go
@@ -29,6 +29,7 @@ type Flags struct {
 
 type unusedVisitor struct {
 	fileSet             *token.FileSet
+	currentFile         *token.File
 	resultsSet          map[string]struct{}
 	includeNamedReturns bool
 	includeReceivers    bool
@@ -106,9 +107,11 @@ func (v *unusedVisitor) Visit(node ast.Node) ast.Visitor {
 		}
 		stmtList = v.handleFuncDecl(paramMap, funcDecl, stmtList)
 		file = v.fileSet.File(funcDecl.Pos())
+		v.currentFile = file
 
 	case *ast.File:
 		file = v.fileSet.File(topLevelType.Pos())
+		v.currentFile = file
 		if topLevelType.Decls != nil {
 			stmtList = v.handleDecls(paramMap, topLevelType.Decls, stmtList)
 		}
@@ -244,7 +247,7 @@ func (v *unusedVisitor) handleStmts(paramMap map[string]bool, stmtList []ast.Stm
 			// no-op
 
 		default:
-			log.Printf("ERROR: unknown stmt type %T\n", s)
+			log.Printf("ERROR: unknown stmt type %T in file %v\n", s, v.currentFile.Name())
 		}
 
 		stmtList = stmtList[1:]
@@ -363,7 +366,7 @@ func (v *unusedVisitor) handleExprs(paramMap map[string]bool, exprList []ast.Exp
 			// no op
 
 		default:
-			log.Printf("ERROR: unknown expr type %T\n", e)
+			log.Printf("ERROR: unknown expr type %T in file %v\n", e, v.currentFile.Name())
 		}
 		exprList = exprList[1:]
 	}

--- a/testdata/test.go
+++ b/testdata/test.go
@@ -53,7 +53,7 @@ func variableCapturedByClosure(r int) {
 	feedTokens(5)
 }
 
-//TODO - functions as keys
+// TODO - functions as keys
 // var usedAsGlobalInterfaceMapValue = map[string]interface{}{
 // 	"someFunc": func(i int, s string) {
 // 		if i == 0 {


### PR DESCRIPTION
- Show file name in `ERROR: unknown stmt/expr type` errors
- Some refactoring in `Visit` func for better readability
- Update `.gitignore` for when you run `go build ./cmd/nargs/` from root
- Fix fmt in `testdata/test.go`
