### PR TITLE
Some cleaning

### DIFF
--- a/import.go
+++ b/import.go
@@ -132,7 +132,7 @@ func importPathsNoDotExpansion(args []string) []string {
 		// as a courtesy to Windows developers, rewrite \ to /
 		// in command-line arguments.  Handles .\... and so on.
 		if filepath.Separator == '\\' {
-			a = strings.Replace(a, `\`, `/`, -1)
+			a = strings.ReplaceAll(a, `\`, `/`)
 		}
 
 		// Put argument in canonical form, but preserve leading ./.
@@ -177,7 +177,7 @@ func importPaths(args []string) []string {
 // is no other special syntax.
 func matchPattern(pattern string) func(name string) bool {
 	re := regexp.QuoteMeta(pattern)
-	re = strings.Replace(re, `\.\.\.`, `.*`, -1)
+	re = strings.ReplaceAll(re, `\.\.\.`, `.*`)
 	// Special case: foo/... matches foo too.
 	if strings.HasSuffix(re, `/.*`) {
 		re = re[:len(re)-len(`/.*`)] + `(/.*)?`

--- a/nargs.go
+++ b/nargs.go
@@ -143,7 +143,13 @@ func (v *unusedVisitor) Visit(node ast.Node) ast.Visitor {
 
 		// TODO print parameter vs parameter(s)?
 		// TODO differentiation of used parameter vs. receiver?
-		resStr := fmt.Sprintf("%v:%v %v contains unused parameter %v\n", file.Name(), file.Position(funcDecl.Pos()).Line, funcDecl.Name.Name, paramName)
+		resStr := fmt.Sprintf(
+			"%v:%v %v contains unused parameter %v\n",
+			file.Name(),
+			file.Position(funcDecl.Pos()).Line,
+			funcDecl.Name.Name,
+			paramName,
+		)
 		v.resultsSet[resStr] = struct{}{}
 		v.errsFound = true
 	}
@@ -374,7 +380,12 @@ func (v *unusedVisitor) handleExprs(paramMap map[string]bool, exprList []ast.Exp
 	return stmtList
 }
 
-func handleFieldList(paramMap map[string]bool, fieldList *ast.FieldList, exprList []ast.Expr, stmtList []ast.Stmt) ([]ast.Expr, []ast.Stmt) {
+func handleFieldList(
+	paramMap map[string]bool,
+	fieldList *ast.FieldList,
+	exprList []ast.Expr,
+	stmtList []ast.Stmt,
+) ([]ast.Expr, []ast.Stmt) {
 	if fieldList == nil {
 		return exprList, stmtList
 	}
@@ -452,14 +463,24 @@ func (v *unusedVisitor) handleFuncLit(paramMap map[string]bool, funcLit *ast.Fun
 			if !used && paramName != "_" {
 				// TODO: this append currently causes things to appear out of order (2)
 				file := v.fileSet.File(funcLit.Pos())
-				resStr := fmt.Sprintf("%v:%v %v contains unused parameter %v\n", file.Name(), file.Position(funcLit.Pos()).Line, funcName.Name, paramName)
+				resStr := fmt.Sprintf(
+					"%v:%v %v contains unused parameter %v\n",
+					file.Name(),
+					file.Position(funcLit.Pos()).Line,
+					funcName.Name,
+					paramName,
+				)
 				v.resultsSet[resStr] = struct{}{}
 			}
 		}
 	}
 }
 
-func (v *unusedVisitor) handleFuncDecl(paramMap map[string]bool, funcDecl *ast.FuncDecl, initialStmts []ast.Stmt) []ast.Stmt {
+func (v *unusedVisitor) handleFuncDecl(
+	paramMap map[string]bool,
+	funcDecl *ast.FuncDecl,
+	initialStmts []ast.Stmt,
+) []ast.Stmt {
 	if funcDecl.Body != nil {
 		initialStmts = append(initialStmts, funcDecl.Body.List...)
 	}

--- a/nargs_test.go
+++ b/nargs_test.go
@@ -86,7 +86,11 @@ func TestCheckForUnusedFunctionArgs(t *testing.T) {
 				t.Errorf("CheckForUnusedFunctionArgs()\ngot = %v,\nwant %v", gotResults, tt.wantResults)
 			}
 			if gotExitWithStatus != tt.wantExitWithStatus {
-				t.Errorf("CheckForUnusedFunctionArgs() gotExitWithStatus = %v, want %v", gotExitWithStatus, tt.wantExitWithStatus)
+				t.Errorf(
+					"CheckForUnusedFunctionArgs() gotExitWithStatus = %v, want %v",
+					gotExitWithStatus,
+					tt.wantExitWithStatus,
+				)
 			}
 		})
 	}


### PR DESCRIPTION
503f4f5 use `strings.ReplaceAll` in import.go
df8fc3e break lines wider than 120
